### PR TITLE
FSharp.Core 4.3.4

### DIFF
--- a/FsAst.fsproj
+++ b/FsAst.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="CreateAst.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.3.4" />
     <PackageReference Include="Fantomas" Version="2.8.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Set the minimum FSharp.Core to .4.3.4 instead of the implicit 4.5.2. See https://github.com/fsharp/fsharp.github.io/pull/89